### PR TITLE
Don't start shell as login

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -22,7 +22,7 @@ var spawnWithBash = function(cmd, opts): child_process.ChildProcess {
 			shell = '/bin/bash';
 		}
 		if (shell.endsWith('bash') || shell.endsWith('zsh')) {
-			var shellArgs = ['-l', '-c', shellEscape(cmd)];
+			var shellArgs = ['-c', shellEscape(cmd)];
 			return child_process.spawn(shell, shellArgs, opts);
 		} else {
 			return crossSpawn(cmd.shift(), cmd, opts);


### PR DESCRIPTION
Not only does this appear to be unnecessary, it also prevents ENV vars from being inherited.
This is problematic especially in the case where RVM is being used.

Fixes https://github.com/castwide/vscode-solargraph/issues/63