### PR TITLE
Run solargraph in interactive zsh shell

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -24,7 +24,7 @@ var spawnWithBash = function(cmd, opts): child_process.ChildProcess {
 		if (shell.endsWith('bash') || shell.endsWith('zsh')) {
 			var shellArgs = ['-l', '-c', shellEscape(cmd)];
 			if (shell.endsWith('zsh')) {
-				shellArgs.unshift('-i')
+				shellArgs.unshift('-i');
 			}
 			return child_process.spawn(shell, shellArgs, opts);
 		} else {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -23,6 +23,9 @@ var spawnWithBash = function(cmd, opts): child_process.ChildProcess {
 		}
 		if (shell.endsWith('bash') || shell.endsWith('zsh')) {
 			var shellArgs = ['-l', '-c', shellEscape(cmd)];
+			if (shell.endsWith('zsh')) {
+				shellArgs.unshift('-i')
+			}
 			return child_process.spawn(shell, shellArgs, opts);
 		} else {
 			return crossSpawn(cmd.shift(), cmd, opts);


### PR DESCRIPTION
Hey thanks again- I've been really loving having a ruby language server in atom!

Strangely, after things had been running great for a while, I started getting gem incompatibility issues when starting up the solargraph server.  Tracked it down to RVM not loading in the shell that was used to run the command.  Making it an interactive shell got RVM loading and fixed the issue.