### PR TITLE
Support WSL

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -5,14 +5,16 @@ export class Configuration {
 	private _commandPath:string;
 	private _withSnippets:Boolean;
 	private _viewsPath:string;
+	private _useWSL:Boolean;
 
-	public constructor(workspace:string = null, useBundler:Boolean = false, bundlerPath:string = "bundle", commandPath:string = 'solargraph', withSnippets:Boolean = false, viewsPath:string = null) {
+	public constructor(workspace:string = null, useBundler:Boolean = false, bundlerPath:string = "bundle", commandPath:string = 'solargraph', withSnippets:Boolean = false, viewsPath:string = null, useWSL:Boolean = false) {
 		this._workspace = workspace;
 		this._useBundler = useBundler;
 		this._bundlerPath = bundlerPath;
 		this._commandPath = commandPath;
 		this._withSnippets = withSnippets;
 		this._viewsPath = viewsPath;
+		this._useWSL = useWSL;
 	}
 
 	get workspace():string {
@@ -61,5 +63,13 @@ export class Configuration {
 
 	set viewsPath(path:string) {
 		this._viewsPath = path;
+	}
+
+	get useWSL():Boolean {
+		return this._useWSL;
+	}
+
+	set useWSL(bool:Boolean) {
+		this._useWSL = bool;
 	}
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -42,10 +42,12 @@ var spawnWithBash = function(cmd, opts): child_process.ChildProcess {
 	}
 }
 
-export function solargraphCommand(args: string[], configuration: Configuration): child_process.ChildProcess {
+export function solargraphCommand(args: string[], configuration: Configuration, spawn: Function = crossSpawn): child_process.ChildProcess {
 	let cmd = [];
 	if (configuration.useBundler && configuration.workspace) {
 		cmd.push(configuration.bundlerPath, 'exec', 'solargraph');
+	} else if(configuration.useWSL) {
+		cmd.push('wsl', configuration.commandPath);
 	} else {
 		cmd.push(configuration.commandPath);
 	}
@@ -58,7 +60,7 @@ export function solargraphCommand(args: string[], configuration: Configuration):
 		// When using a specified command path, assume shell magic is not
 		// necessary
 		cmd = cmd.concat(args);
-		return crossSpawn(cmd.shift(), cmd, env);
+		return spawn(cmd.shift(), cmd, env);
 	}
 }
 

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -81,6 +81,24 @@ suite('solargraphCommand', () => {
 			done();
 		});
 	});
+
+	it('works with WSL', (done) => {
+		let cmd = 'solargraph';
+		if ((platform().match(/darwin|linux/))) {
+			cmd += '.rb';
+		} else {
+			cmd += '.bat';
+		}
+		const commandPath = path.resolve('.', 'src', 'tests', 'bin', cmd);
+		configuration.commandPath = commandPath;
+		configuration.useWSL = true;
+		solargraph.commands.solargraphCommand(['-v'], configuration, (cmd, args, env) => {
+			expect(cmd).to.equal('wsl');
+			expect(args).to.eql([commandPath, '-v']);
+			expect(env).not.to.equal(undefined);
+			done();
+		});
+	})
 });
 
 suite('SocketProvider', () => {


### PR DESCRIPTION
This PR adds support for WSL (Windows Subsystem for Linux). In order to reach WSL's Ruby, we need to add `wsl` before the Linux path, as described [here](https://docs.microsoft.com/en-us/windows/wsl/interop#run-linux-tools-from-a-windows-command-line).

    $ wsl /usr/bin/ruby
    # or using rvm
    $ wsl /home/<my_user>/.rvm/gems/ruby-2.6.6/wrappers/ruby
    # for reaching solargraph binary
    $ wsl /home/<my_user>/.rvm/gems/ruby-2.6.6/wrappers/solargraph

This PR implements `useWSL` flag in the configuration so it will append `wsl` to the `commandPath`, so you can use it as such:

```javascript
import * as solargraph from 'solargraph-utils';
let configuration = new solargraph.Configuration(useWSL: true, commandPath: '/home/<my_user>/.rvm/gems/ruby-2.6.6/wrappers/solargraph');
let provider = new solargraph.SocketProvider(configuration);
provider.start().then(() => {
    console.log('Socket server is listening on port ' + provider.port);
});
```